### PR TITLE
Makefile: Dehardcode compiler and cflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 
+CFLAGS = -Wall -O3
+
 all: ttyplot
 
 ttyplot: ttyplot.c
-	gcc ttyplot.c -o ttyplot -Wall -O3 -lcurses
+	$(CC) $< -o $@ $(CFLAGS) $(LDFLAGS) -lcurses
 
 clean:
 	rm -f ttyplot


### PR DESCRIPTION
It is generally nicer to not hard code the compiler and cflags so that the Makefile works in more use cases e.g. cross compiling, systems that have clang installed and so on.
Note `$(CC)` defaults to gcc if it is unset.