### PR TITLE
Makefile tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-
-CFLAGS = -Wall -O3
+CFLAGS += -Wall -O3
 
 all: ttyplot
 

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,7 @@
 CFLAGS += -Wall -O3
+LDLIBS += -lcurses
 
 all: ttyplot
-
-ttyplot: ttyplot.c
-	$(CC) $< -o $@ $(CFLAGS) $(LDFLAGS) -lcurses
-
-torture: torture.c
-	$(CC) $< -o $@ $(CFLAGS) $(LDFLAGS)
 
 clean:
 	rm -f ttyplot torture

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS += -Wall -O3
+CFLAGS += -Wall
 LDLIBS += -lcurses
 
 all: ttyplot

--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,5 @@ all: ttyplot
 
 clean:
 	rm -f ttyplot torture
+
+.PHONY: all clean


### PR DESCRIPTION
 - Respect system CFLAGS by adding to it, rather than overriding.

 - Use built-in inference rules for compilation. It's shorter but technically the defaults may be better suited to the system or build environment.

- Don't override default optimization level. Except in specific cases the system wide configuration should be respected.

 - Mark 'clean' as a phony target, which is to say that it's not a file target so the existence of a 'clean' file doesn't satisfy the target.

All matters of taste though so no hurt feelings if you disagree!