### PR TITLE
Add install and uninstall targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+DESTDIR ?=
+PREFIX  ?= /usr/local
 
 CFLAGS = -Wall -O3
 
@@ -9,5 +11,14 @@ ttyplot: ttyplot.c
 torture: torture.c
 	$(CC) $< -o $@ $(CFLAGS) $(LDFLAGS)
 
+install: ttyplot
+	install -d $(DESTDIR)$(PREFIX)/bin
+	install -m755 ttyplot $(DESTDIR)$(PREFIX)/bin
+
+uninstall:
+	rm -f $(PREFIX)$(PREFIX)/bin/ttyplot
+
 clean:
 	rm -f ttyplot torture
+
+.PHONY: all clean install uninstall

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-DESTDIR ?=
-PREFIX  ?= /usr/local
+DESTDIR   ?=
+PREFIX    ?= /usr/local
+MANPREFIX ?= $(PREFIX)/man
 
 CFLAGS = -Wall -O3
 
@@ -11,12 +12,15 @@ ttyplot: ttyplot.c
 torture: torture.c
 	$(CC) $< -o $@ $(CFLAGS) $(LDFLAGS)
 
-install: ttyplot
+install: ttyplot ttyplot.1
 	install -d $(DESTDIR)$(PREFIX)/bin
-	install -m755 ttyplot $(DESTDIR)$(PREFIX)/bin
+	install -d $(DESTDIR)$(MANPREFIX)/man1
+	install -m755 ttyplot   $(DESTDIR)$(PREFIX)/bin
+	install -m644 ttyplot.1 $(DESTDIR)$(MANPREFIX)/man1
 
 uninstall:
 	rm -f $(PREFIX)$(PREFIX)/bin/ttyplot
+	rm -f $(PREFIX)$(MANPREFIX)/man1/ttyplot.1
 
 clean:
 	rm -f ttyplot torture


### PR DESCRIPTION
PREFIX is where the program is found after installation, e.g. /usr or /usr/local.

DESTDIR can be used by package build tools and such as a staging directory from which the package is created.