### PR TITLE
Makefile: Use pkg-config for systems where ncurses is not libcurses.so (fixes #66)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ DESTDIR   ?=
 PREFIX    ?= /usr/local
 MANPREFIX ?= $(PREFIX)/man
 CFLAGS += -Wall -Wextra
-LDLIBS += -lcurses -ltinfo
+LDLIBS += `pkg-config --libs ncurses 2>/dev/null || echo '-lcurses -ltinfo'`
 PKG = ttyplot_1.4-1
 PKGDIR = $(PKG)/usr/local/bin
 


### PR DESCRIPTION
Fixes #66

I'm happy to adjust and discuss.