### PR TITLE
Fix signal handler function signatures

### DIFF
--- a/ttyplot.c
+++ b/ttyplot.c
@@ -199,7 +199,8 @@ void paint_plot() {
     sigprocmask(SIG_UNBLOCK, &sigmsk, NULL);
 }
 
-void resize() {
+void resize(int signum) {
+    (void)signum;
     sigprocmask(SIG_BLOCK, &sigmsk, NULL);
     endwin();
     refresh();
@@ -208,7 +209,8 @@ void resize() {
     paint_plot();
 }
 
-void finish() {
+void finish(int signum) {
+    (void)signum;
     sigprocmask(SIG_BLOCK, &sigmsk, NULL);
     curs_set(FALSE);
     echo();
@@ -288,8 +290,8 @@ int main(int argc, char *argv[]) {
     mvprintw(height/2, (width/2)-14, "waiting for data from stdin");
     refresh();
 
-    signal(SIGWINCH, (void*)resize);
-    signal(SIGINT, (void*)finish);
+    signal(SIGWINCH, resize);
+    signal(SIGINT, finish);
     sigemptyset(&sigmsk);
     sigaddset(&sigmsk, SIGWINCH);
 


### PR DESCRIPTION
Previously, e.g. GCC 11 was warning:
> ```console
> # CFLAGS='-std=gnu99 -pedantic' make
> cc -std=gnu99 -pedantic -Wall -Wextra    ttyplot.c  -lncurses -ltinfo -o ttyplot
> ttyplot.c: In function ‘main’:
> ttyplot.c:291:22: warning: ISO C forbids conversion of function pointer to object pointer type [-Wpedantic]
>   291 |     signal(SIGWINCH, (void*)resize);
>       |                      ^
> ttyplot.c:291:22: warning: ISO C forbids passing argument 2 of ‘signal’ between function pointer and ‘void *’ [-Wpedantic]
>   291 |     signal(SIGWINCH, (void*)resize);
>       |                      ^~~~~~~~~~~~~
> In file included from ttyplot.c:15:
> /usr/include/signal.h:88:57: note: expected ‘__sighandler_t’ {aka ‘void (*)(int)’} but argument is of type ‘void *’
>    88 | extern __sighandler_t signal (int __sig, __sighandler_t __handler)
>       |                                          ~~~~~~~~~~~~~~~^~~~~~~~~
> ttyplot.c:292:20: warning: ISO C forbids conversion of function pointer to object pointer type [-Wpedantic]
>   292 |     signal(SIGINT, (void*)finish);
>       |                    ^
> ttyplot.c:292:20: warning: ISO C forbids passing argument 2 of ‘signal’ between function pointer and ‘void *’ [-Wpedantic]
>   292 |     signal(SIGINT, (void*)finish);
>       |                    ^~~~~~~~~~~~~
> In file included from ttyplot.c:15:
> /usr/include/signal.h:88:57: note: expected ‘__sighandler_t’ {aka ‘void (*)(int)’} but argument is of type ‘void *’
>    88 | extern __sighandler_t signal (int __sig, __sighandler_t __handler)
>       |                                          ~~~~~~~~~~~~~~~^~~~~~~~~
> ```