### PR TITLE
Pin GitHub Actions to specific commits for security

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -69,7 +69,7 @@ jobs:
               clang-${{ matrix.clang_major_version }}
 
       - name: Checkout Git branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
 
       - name: 'Build'
         env:


### PR DESCRIPTION
For proof that GitHub Dependabot can still keep things up to date for us with the new format see https://github.com/gentoo-ev/www.gentoo-ev.org/pull/5/files .