### PR TITLE
Fix `make torture`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ CFLAGS += -Wall -Wextra
 LDLIBS += `pkg-config --libs ncurses 2>/dev/null || echo '-lcurses -ltinfo'`
 PKG = ttyplot_1.4-1
 PKGDIR = $(PKG)/usr/local/bin
+torture: LDLIBS = -lm
 
 all: ttyplot
 


### PR DESCRIPTION
Although the `torture` program is presumably not meant for the end user, it is a good test for `ttyplot`. Besides, its presence in the repo is a strong incentive for typing `make torture`, which fails on undefined references to `sin` and `cos`.

The fix is a single line added to the Makefile.