### PR TITLE
Fix “unused parameter” warning in torture.c

### DIFF
--- a/torture.c
+++ b/torture.c
@@ -11,6 +11,7 @@
 #include <math.h>
 
 int main(int argc, char *argv[]) {
+    (void) argv;
     int n;
 
     for(n=0;;n+=5) {


### PR DESCRIPTION
This warning is fixed with the idiom already used in the signal handlers of ttyplot.c, namely `(void) the_unused_parameter`.