### PR TITLE
README.md: Document installation on Gentoo

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ alternatively [download packages](https://packages.debian.org/sid/ttyplot)
 
 [debian tracker](https://tracker.debian.org/pkg/ttyplot)
 
+### gentoo
+
+```
+emerge -av app-admin/ttyplot
+```
+
 ### macOS
 
 ```


### PR DESCRIPTION
Related: https://github.com/gentoo/gentoo/commit/47315ecb859ff85be2dcfec818108517bb285208

Depends on #94 for a fully green CI.