### PR TITLE
Get signal handling into the land of defined behavior (fixes #62)

### DIFF
--- a/ttyplot.c
+++ b/ttyplot.c
@@ -200,13 +200,15 @@ void paint_plot(void) {
     mvaddstr(height-2, width-strlen(ls), ls);
 
     mvvline(height-2, 5, plotchar|A_NORMAL, 1);
-    mvprintw(height-2, 7, "last=%.1f min=%.1f max=%.1f avg=%.1f %s ",  values1[n], min1, max1, avg1, unit);
-    if(rate)
-        printw(" interval=%llds", (long long int)td);
+    if (v > 0) {
+        mvprintw(height-2, 7, "last=%.1f min=%.1f max=%.1f avg=%.1f %s ",  values1[n], min1, max1, avg1, unit);
+        if(rate)
+            printw(" interval=%llds", (long long int)td);
 
-    if(two) {
-        mvaddch(height-1, 5, ' '|A_REVERSE);
-        mvprintw(height-1, 7, "last=%.1f min=%.1f max=%.1f avg=%.1f %s   ",  values2[n], min2, max2, avg2, unit);
+        if(two) {
+            mvaddch(height-1, 5, ' '|A_REVERSE);
+            mvprintw(height-1, 7, "last=%.1f min=%.1f max=%.1f avg=%.1f %s   ",  values2[n], min2, max2, avg2, unit);
+        }
     }
 
     plot_values(plotheight, plotwidth, values1, values2, max, hardmin, n, plotchar, max_errchar, min_errchar, hardmax);


### PR DESCRIPTION
Hi!

The current signal handling code is not robust and undefined behavior (according to https://wiki.sei.cmu.edu/confluence/display/c/SIG31-C.+Do+not+access+shared+objects+in+signal+handlers).

There are many ways to address this problem, and I'd like to present one approach here for review.

I saw only after coding this that use of pthreads was said to be not welcome in #62 to support systems without pthreads. If that's still status quo then the only threadless alternative will likely be to do fully non-blocking stdin I/O and I just learned things while building for the trashcan… Status quo on `master` really needs some fix, it's not robust.

These decisions went into the current implementation:
- Signal handlers only set integer flags of type `volatile sig_atomic_t` and the actually handling is done elsewhere.
- Signal handling or stdin reading need to happen in separate threads now (because stdin reading is blocking and we cannot have signal handling blocked).
- I decided to keep all access to Curses and signals on the main thread and move stdin data extraction to a separate thread.
- So now we have a reader and a write on a shared resource — the plot data — and hence need some synchronisation to not plot in-between state, I used a mutex for that.
- Also, the code sits on top of pull request #97 with minimum window size handling and includes that feature with adaptions.

Let me know what you think, best, Sebastian

Depends on #94 for a fully green CI.