### PR TITLE
Support plotting with multibyte characters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ DESTDIR   ?=
 PREFIX    ?= /usr/local
 MANPREFIX ?= $(PREFIX)/man
 CFLAGS += -Wall -Wextra
+CFLAGS += `pkg-config --cflags ncursesw`
 LDLIBS += `pkg-config --libs ncursesw`
 torture: LDLIBS = -lm
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ DESTDIR   ?=
 PREFIX    ?= /usr/local
 MANPREFIX ?= $(PREFIX)/man
 CFLAGS += -Wall -Wextra
-LDLIBS += `pkg-config --libs ncurses`
+LDLIBS += `pkg-config --libs ncursesw`
 torture: LDLIBS = -lm
 
 all: ttyplot

--- a/ttyplot.c
+++ b/ttyplot.c
@@ -5,6 +5,11 @@
 // Apache License 2.0
 //
 
+// This is needed on macOS to get the ncurses widechar API, and pkg-config fails to define it.
+#ifdef __APPLE__
+#define _XOPEN_SOURCE_EXTENDED
+#endif
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/ttyplot.c
+++ b/ttyplot.c
@@ -31,17 +31,15 @@
     #define VERSION_STR STR(VERSION_MAJOR) "." STR(VERSION_MINOR) "." STR(VERSION_PATCH)
 #endif
 
+#define T_RARR '>'
+#define T_UARR '^'
 #ifdef NOACS
 #define T_HLINE '-'
 #define T_VLINE '|'
-#define T_RARR '>'
-#define T_UARR '^'
 #define T_LLCR 'L'
 #else
 #define T_HLINE ACS_HLINE
 #define T_VLINE ACS_VLINE
-#define T_RARR ACS_RARROW
-#define T_UARR ACS_UARROW
 #define T_LLCR ACS_LLCORNER
 #endif
 

--- a/ttyplot.c
+++ b/ttyplot.c
@@ -5,7 +5,6 @@
 // Apache License 2.0
 //
 
-#define _XOPEN_SOURCE 500  // Get ncurses wchar_t support from SUSv2 (UNIX 98)
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
This pull request addresses issue #84. Note that, in order for ncurses to support non-ASCII characters, we need to:

* Ask for wide character support by defining a suitable macro before including `<curses.h>`. I went for `_XOPEN_SOURCE`, but we could use the more explicit `NCURSES_WIDECHAR` instead.

* Link with the version of the library that provides this support. On my system (Ubuntu 22.04), this is ncursesw.so. Some tests should be done on other OSes in order to find the suitable link options.

One drawback of using the wide character version of `mvvline()` is that it does not support ACS (alternative character set) characters. Since we cannot draw with `ACS_VLINE`, we default to the visually equivalent “│” (U+2502 box drawings light vertical). This, however, cannot be done on the C locale (or any other 8-bit locale). In this case we use the ASCII character “|” (U+007C vertical line), which unfortunately leaves tiny gaps between successive character cells.

With this PR, the command:

```shell
{ ./torture | head -75; sleep 1m; } | ./ttyplot -c ╳
```

displays:

![screenshot](https://github.com/tenox7/ttyplot/assets/7680786/99041fb1-4f40-4c98-a562-ceecd3ae8999)

I tested with multiple plotting characters, inside and outside the BMP, and also with ASCII characters in the C locale. It works for me, but more testing would be welcome, especially on OSes other than Ubuntu.

Fixes #84.