### PR TITLE
Handle keyboard input

### DIFF
--- a/ttyplot.c
+++ b/ttyplot.c
@@ -200,13 +200,15 @@ void paint_plot(void) {
     mvaddstr(height-2, width-strlen(ls), ls);
 
     mvvline(height-2, 5, plotchar|A_NORMAL, 1);
-    mvprintw(height-2, 7, "last=%.1f min=%.1f max=%.1f avg=%.1f %s ",  values1[n], min1, max1, avg1, unit);
-    if(rate)
-        printw(" interval=%llds", (long long int)td);
+    if (v > 0) {
+        mvprintw(height-2, 7, "last=%.1f min=%.1f max=%.1f avg=%.1f %s ",  values1[n], min1, max1, avg1, unit);
+        if(rate)
+            printw(" interval=%llds", (long long int)td);
 
-    if(two) {
-        mvaddch(height-1, 5, ' '|A_REVERSE);
-        mvprintw(height-1, 7, "last=%.1f min=%.1f max=%.1f avg=%.1f %s   ",  values2[n], min2, max2, avg2, unit);
+        if(two) {
+            mvaddch(height-1, 5, ' '|A_REVERSE);
+            mvprintw(height-1, 7, "last=%.1f min=%.1f max=%.1f avg=%.1f %s   ",  values2[n], min2, max2, avg2, unit);
+        }
     }
 
     plot_values(plotheight, plotwidth, values1, values2, max, hardmin, n, plotchar, max_errchar, min_errchar, hardmax);

--- a/ttyplot.c
+++ b/ttyplot.c
@@ -446,6 +446,9 @@ int main(int argc, char *argv[]) {
                     rate = !rate;
                 else if (key == 'q')  // 'q' = quit
                     break;
+            } else if (count == 0) {
+                close(tty);
+                tty = -1;
             }
         }
 

--- a/ttyplot.c
+++ b/ttyplot.c
@@ -442,7 +442,9 @@ int main(int argc, char *argv[]) {
             char key;
             int count = read(tty, &key, 1);
             if (count == 1) {  // we did catch a keystroke
-                if (key == 'q')  // 'q' = quit
+                if (key == 'r')  // 'r' = toggle rate mode
+                    rate = !rate;
+                else if (key == 'q')  // 'q' = quit
                     break;
             }
         }


### PR DESCRIPTION
The normal way to stop ttyplot is by typing <kbd>Ctrl</kbd>-<kbd>C</kbd>. This is unfortunate, as this key combination is normally only ever used for interrupting an unresponsive program: well behaved programs can be terminated by some regular (not signal) keyboard command.

This pull request makes ttyplot quit when the user hits <kbd>q</kbd> on the keyboard. This is the same key used to terminate more, less, htop, ncdu, and other full-screen terminal programs. Once we monitor keyboard input, adding extra keybindings is cheap. Then, as a bonus, the <kbd>r</kbd> key toggles rate mode on and off.

Keyboard commands only work when stdin is redirected (our most common use case), as otherwise keyboard input is interpreted as data. It works by reading the keystrokes from the controlling terminal (`/dev/tty`).

This pull request depends on PR #98, which creates the required framework for concurrently watching multiple event sources.