### PR TITLE
Add options to stresstest.c

### DIFF
--- a/stresstest.c
+++ b/stresstest.c
@@ -9,19 +9,24 @@
 #include <stdbool.h>
 #include <time.h>
 #include <unistd.h>
+#include <string.h>
 #include <math.h>
 
 const char help[] =
-    "Usage: %s [-h] [-2] [-r rate]\n"
+    "Usage: %s [-h] [-2] [-c] [-r rate]\n"
     "  -h       print this help message and exit\n"
     "  -2       output two waves\n"
+    "  -c       randomly chunk the output\n"
     "  -r rate  sample rate in samples/s (default: 100)\n";
 
-const char optstring[] = "h2r:";
+const char optstring[] = "h2cr:";
 
 int main(int argc, char *argv[]) {
+    char buffer[1024];
+    size_t buffer_pos = 0;
     int opt;
     bool two_waves = false;
+    bool chunked = false;
     double rate = 100;
 
     // Parse the command line.
@@ -32,6 +37,9 @@ int main(int argc, char *argv[]) {
                 return EXIT_SUCCESS;
             case '2':
                 two_waves = true;
+                break;
+            case 'c':
+                chunked = true;
                 break;
             case 'r':
                 rate = atof(optarg);
@@ -49,10 +57,24 @@ int main(int argc, char *argv[]) {
     const useconds_t delay = 1e6 / rate;
 
     for (unsigned int n=0; ; n+=5) {
-        printf("%.1f\n", (sin(n*M_PI/180)*5)+5);
+        buffer_pos += sprintf(buffer + buffer_pos, "%.1f\n", (sin(n*M_PI/180)*5)+5);
         if(two_waves)
-            printf("%.1f\n", (cos(n*M_PI/180)*5)+5);
-        fflush(stdout);
+            buffer_pos += sprintf(buffer + buffer_pos, "%.1f\n", (cos(n*M_PI/180)*5)+5);
+        if (chunked) {
+            size_t send_pos = 0;
+            while (buffer_pos - send_pos >= 16) {
+                const size_t bytes_to_send = 1 + rand() % 16;  // 1..16
+                write(STDOUT_FILENO, buffer + send_pos, bytes_to_send);
+                usleep(50);  // let ttyplot read this before proceeding
+                send_pos += bytes_to_send;
+            }
+            if (send_pos > 0 && send_pos < buffer_pos)
+                memmove(buffer, buffer + send_pos, buffer_pos - send_pos);
+            buffer_pos -= send_pos;
+        } else {
+            write(STDOUT_FILENO, buffer, buffer_pos);
+            buffer_pos = 0;
+        }
         usleep(delay);
     }
 

--- a/stresstest.c
+++ b/stresstest.c
@@ -6,17 +6,44 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <time.h>
 #include <unistd.h>
 #include <math.h>
 
-int main(int argc, char *argv[]) {
-    (void) argv;
-    unsigned int n;
+const char help[] =
+    "Usage: %s [-h] [-2]\n"
+    "  -h       print this help message and exit\n"
+    "  -2       output two waves\n";
 
-    for(n=0;;n+=5) {
+const char optstring[] = "h2";
+
+int main(int argc, char *argv[]) {
+    int opt;
+    bool two_waves = false;
+
+    // Parse the command line.
+    while ((opt = getopt(argc, argv, optstring)) != -1) {
+        switch (opt) {
+            case 'h':
+                printf(help, argv[0]);
+                return EXIT_SUCCESS;
+            case '2':
+                two_waves = true;
+                break;
+            default:
+                fprintf(stderr, help, argv[0]);
+                return EXIT_FAILURE;
+        }
+    }
+    if (argc > optind) {
+        fprintf(stderr, help, argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    for (unsigned int n=0; ; n+=5) {
         printf("%.1f\n", (sin(n*M_PI/180)*5)+5);
-        if(argc==2)
+        if(two_waves)
             printf("%.1f\n", (cos(n*M_PI/180)*5)+5);
         fflush(stdout);
         usleep(10000);

--- a/stresstest.c
+++ b/stresstest.c
@@ -13,13 +13,14 @@
 #include <math.h>
 
 const char help[] =
-    "Usage: %s [-h] [-2] [-c] [-r rate]\n"
+    "Usage: %s [-h] [-2] [-c] [-g] [-r rate]\n"
     "  -h       print this help message and exit\n"
     "  -2       output two waves\n"
     "  -c       randomly chunk the output\n"
+    "  -g       occasionally output garbage\n"
     "  -r rate  sample rate in samples/s (default: 100)\n";
 
-const char optstring[] = "h2cr:";
+const char optstring[] = "h2cgr:";
 
 int main(int argc, char *argv[]) {
     char buffer[1024];
@@ -27,6 +28,7 @@ int main(int argc, char *argv[]) {
     int opt;
     bool two_waves = false;
     bool chunked = false;
+    bool add_garbage = false;
     double rate = 100;
 
     // Parse the command line.
@@ -40,6 +42,9 @@ int main(int argc, char *argv[]) {
                 break;
             case 'c':
                 chunked = true;
+                break;
+            case 'g':
+                add_garbage = true;
                 break;
             case 'r':
                 rate = atof(optarg);
@@ -58,8 +63,13 @@ int main(int argc, char *argv[]) {
 
     for (unsigned int n=0; ; n+=5) {
         buffer_pos += sprintf(buffer + buffer_pos, "%.1f\n", (sin(n*M_PI/180)*5)+5);
-        if(two_waves)
+        if (add_garbage && rand() <= RAND_MAX / 5)
+            buffer_pos += sprintf(buffer + buffer_pos, "garbage ");
+        if (two_waves) {
             buffer_pos += sprintf(buffer + buffer_pos, "%.1f\n", (cos(n*M_PI/180)*5)+5);
+            if (add_garbage && rand() <= RAND_MAX / 5)
+                buffer_pos += sprintf(buffer + buffer_pos, "garbage ");
+        }
         if (chunked) {
             size_t send_pos = 0;
             while (buffer_pos - send_pos >= 16) {

--- a/stresstest.c
+++ b/stresstest.c
@@ -13,7 +13,10 @@
 #include <math.h>
 
 const char help[] =
-    "Usage: %s [-h] [-2] [-c] [-g] [-r rate]\n"
+    "Usage:\n"
+    "  stresstest [-2] [-c] [-g] [-r rate]\n"
+    "  stresstest -h\n"
+    "\n"
     "  -h       print this help message and exit\n"
     "  -2       output two waves\n"
     "  -c       randomly chunk the output\n"
@@ -37,7 +40,7 @@ int main(int argc, char *argv[]) {
     while ((opt = getopt(argc, argv, optstring)) != -1) {
         switch (opt) {
             case 'h':
-                printf(help, argv[0]);
+                printf(help);
                 return EXIT_SUCCESS;
             case '2':
                 two_waves = true;
@@ -55,12 +58,12 @@ int main(int argc, char *argv[]) {
                 seed = atoi(optarg);
                 break;
             default:
-                fprintf(stderr, help, argv[0]);
+                fprintf(stderr, help);
                 return EXIT_FAILURE;
         }
     }
     if (argc > optind) {
-        fprintf(stderr, help, argv[0]);
+        fprintf(stderr, help);
         return EXIT_FAILURE;
     }
 

--- a/stresstest.c
+++ b/stresstest.c
@@ -12,15 +12,17 @@
 #include <math.h>
 
 const char help[] =
-    "Usage: %s [-h] [-2]\n"
+    "Usage: %s [-h] [-2] [-r rate]\n"
     "  -h       print this help message and exit\n"
-    "  -2       output two waves\n";
+    "  -2       output two waves\n"
+    "  -r rate  sample rate in samples/s (default: 100)\n";
 
-const char optstring[] = "h2";
+const char optstring[] = "h2r:";
 
 int main(int argc, char *argv[]) {
     int opt;
     bool two_waves = false;
+    double rate = 100;
 
     // Parse the command line.
     while ((opt = getopt(argc, argv, optstring)) != -1) {
@@ -30,6 +32,9 @@ int main(int argc, char *argv[]) {
                 return EXIT_SUCCESS;
             case '2':
                 two_waves = true;
+                break;
+            case 'r':
+                rate = atof(optarg);
                 break;
             default:
                 fprintf(stderr, help, argv[0]);
@@ -41,12 +46,14 @@ int main(int argc, char *argv[]) {
         return EXIT_FAILURE;
     }
 
+    const useconds_t delay = 1e6 / rate;
+
     for (unsigned int n=0; ; n+=5) {
         printf("%.1f\n", (sin(n*M_PI/180)*5)+5);
         if(two_waves)
             printf("%.1f\n", (cos(n*M_PI/180)*5)+5);
         fflush(stdout);
-        usleep(10000);
+        usleep(delay);
     }
 
     return 0;

--- a/stresstest.c
+++ b/stresstest.c
@@ -18,9 +18,10 @@ const char help[] =
     "  -2       output two waves\n"
     "  -c       randomly chunk the output\n"
     "  -g       occasionally output garbage\n"
-    "  -r rate  sample rate in samples/s (default: 100)\n";
+    "  -r rate  sample rate in samples/s (default: 100)\n"
+    "  -s seed  set random seed\n";
 
-const char optstring[] = "h2cgr:";
+const char optstring[] = "h2cgr:s:";
 
 int main(int argc, char *argv[]) {
     char buffer[1024];
@@ -30,6 +31,7 @@ int main(int argc, char *argv[]) {
     bool chunked = false;
     bool add_garbage = false;
     double rate = 100;
+    unsigned int seed = time(NULL);
 
     // Parse the command line.
     while ((opt = getopt(argc, argv, optstring)) != -1) {
@@ -49,6 +51,9 @@ int main(int argc, char *argv[]) {
             case 'r':
                 rate = atof(optarg);
                 break;
+            case 's':
+                seed = atoi(optarg);
+                break;
             default:
                 fprintf(stderr, help, argv[0]);
                 return EXIT_FAILURE;
@@ -60,6 +65,7 @@ int main(int argc, char *argv[]) {
     }
 
     const useconds_t delay = 1e6 / rate;
+    srand(seed);
 
     for (unsigned int n=0; ; n+=5) {
         buffer_pos += sprintf(buffer + buffer_pos, "%.1f\n", (sin(n*M_PI/180)*5)+5);


### PR DESCRIPTION
**Draft pull request**

This pull request adds option parsing, and multiple options to torture.c, which are intended to exercise corner cases in `ttyplot`:

```shell
$ ./torture -h
Usage: ./torture [-h] [-2] [-c] [-g] [-r rate]
  -h       print this help message and exit
  -2       output two waves
  -c       randomly chunk the output
  -g       occasionally output garbage
  -r rate  sample rate in samples/s (default: 100)
```

This PR is marked as “draft” because it is intended to be merged in a future “development” branch, that integrates previous pull requests. A such, it sits on top of my branch “next”, which merges PRs #98, #99, #106, #110 and #114. This PR proper is four commits: see [the diff][].

[the diff]: /edgar-bonet/ttyplot/compare/next..torture-opts
