### PR TITLE
Separate -h and -v from the rest in usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,9 @@ ttyplot also supports *counter* style metrics, calculating *rate* by measured ti
 ## flags
 
 ```
-  ttyplot [-h] [-v] [-2] [-r] [-c plotchar] [-s scale] [-m max] [-M min] [-t title] [-u unit]
+  ttyplot [-2] [-r] [-c plotchar] [-s scale] [-m max] [-M min] [-t title] [-u unit]
+  ttyplot -h
+  ttyplot -v
 
   -2 read two values and draw two plots, the second one is in reverse video
   -r rate of a counter (divide value by measured sample interval)

--- a/ttyplot.c
+++ b/ttyplot.c
@@ -76,7 +76,11 @@ int width=0, height=0, n=-1, r=0, v=0, c=0, rate=0, two=0, plotwidth=0, plotheig
 const char *verstring = "https://github.com/tenox7/ttyplot " VERSION_STR;
 
 void usage(void) {
-    printf("Usage:\n  ttyplot [-h] [-v] [-2] [-r] [-c plotchar] [-s scale] [-m max] [-M min] [-t title] [-u unit]\n\n"
+    printf("Usage:\n"
+            "  ttyplot [-2] [-r] [-c plotchar] [-s scale] [-m max] [-M min] [-t title] [-u unit]\n"
+            "  ttyplot -h\n"
+            "  ttyplot -v\n"
+            "\n"
             "  -2 read two values and draw two plots, the second one is in reverse video\n"
             "  -r rate of a counter (divide value by measured sample interval)\n"
             "  -c character to use for plot line, eg @ # %% . etc\n"


### PR DESCRIPTION
This is similar to what can be seen with e.g. `xmlwf`:

```console
# xmlwf -h |& head -n4
usage:
  xmlwf [OPTIONS] [FILE ...]
  xmlwf -h
  xmlwf -v
```

Will affect #116 also if this idea is found to be consensual.