### PR TITLE
Make CI reject spelling errors using codespell + fix three typos

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,28 @@
+# Copyright (c) 2023 Sebastian Pipping <sebastian@pipping.org>
+# Licensed under Apache License Version 2.0
+
+name: Enforce codespell-clean spelling
+
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: '0 3 * * 5'  # Every Friday at 3am
+  workflow_dispatch:
+
+# Minimum permissions for security
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Enforce codespell-clean spelling
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+
+      - uses: codespell-project/actions-codespell@94259cd8be02ad2903ba34a22d9c13de21a74461  # v2.0
+        with:
+          # "nd" (with lowercase "n") is from ".Nd" (with uppercase "n") in ttyplot.1
+          # https://github.com/codespell-project/codespell/issues/3233#issuecomment-1828026522
+          ignore_words_list: nd

--- a/recordings/get_back_in_sync.sh
+++ b/recordings/get_back_in_sync.sh
@@ -12,7 +12,7 @@ cd "${self_dir}"
 
 if ! git diff --exit-code >/dev/null \
         || ! git diff --cached --exit-code >/dev/null ; then
-    echo 'ERROR: Please commit/stash your uncommited work first, aborting.' >&2
+    echo 'ERROR: Please commit/stash your uncommitted work first, aborting.' >&2
     exit 1
 fi
 

--- a/ttyplot.c
+++ b/ttyplot.c
@@ -470,7 +470,7 @@ int main(int argc, char *argv[]) {
         }
 
         // Block until (a) we receive a signal or (b) stdin can be read without blocking
-        // or (c) timeout expires, in oder to reduce use of CPU and power while idle
+        // or (c) timeout expires, in order to reduce use of CPU and power while idle
         fd_set read_fds;
         FD_ZERO(&read_fds);
         int select_nfds = 0;

--- a/ttyplot.c
+++ b/ttyplot.c
@@ -318,7 +318,7 @@ int main(int argc, char *argv[]) {
     }
 
     setlocale(LC_ALL, "");
-    if (MB_CUR_MAX > 1)            // if non-ASCII characters are supprted:
+    if (MB_CUR_MAX > 1)            // if non-ASCII characters are supported:
         plotchar.chars[0]=0x2502;  // U+2502 box drawings light vertical
     else
         plotchar.chars[0]='|';     // U+007C vertical line


### PR DESCRIPTION
This is a port of https://github.com/libexpat/libexpat/pull/739 to ttyplot. Should help keep our typo count down in the future.