### PR TITLE
Clean up CI stage "Evaluate UI test results" (fix-up for #133)

### DIFF
--- a/.github/workflows/linux_and_macos.yml
+++ b/.github/workflows/linux_and_macos.yml
@@ -156,9 +156,6 @@ jobs:
 
       - name: 'Evaluate UI test results'
         run: |-
-          diff -u recordings/{expected,actual}.txt
-          rm -f recordings/actual.txt
-
           cat <<"EOF"
             ################################################################
             ## If this step FAILS you can get the expected ANSI screenshots
@@ -170,7 +167,8 @@ jobs:
             ################################################################
           EOF
 
-          exit ${error}
+          diff -u recordings/{expected,actual}.txt
+          rm -f recordings/actual.txt
 
       - name: 'Clean'
         env:


### PR DESCRIPTION
Fix-up for #133 

- There is no more `${error}`, that was a leftover
- For the help text to be helpful, it needs to go first, or it will never be seen in case of CI failure…
