### PR TITLE
Fix race condition on clock display (follow-up to #115)

### DIFF
--- a/ttyplot.c
+++ b/ttyplot.c
@@ -591,10 +591,10 @@ int main(int argc, char *argv[]) {
         };
         const int select_ret = select(select_nfds, &read_fds, NULL, NULL, &timeout);
 
+        // Refresh the clock if the seconds have changed.
+        const time_t displayed_time = now.tv_sec;
         gettimeofday(&now, NULL);
-
-        // Refresh the clock on timeouts.
-        if (select_ret == 0)
+        if (now.tv_sec != displayed_time)
             redraw_needed = true;
 
         // Handle signals.


### PR DESCRIPTION
Thinking hard about this clock issue made me realize there is a race here.

If some event (data, keystroke or signal) is delivered very close to the select() timeout, select() could catch it and return a positive value, even though the timeout is just expiring. This means that select() returning zero is not a reliable way of knowing whether the clock display needs to be updated.

Instead of looking at the return value of select(), update the clock when the seconds have changed.