### PR TITLE
Cl: Drop `homebrew/cask-fonts` leftover (follow-up to #133)

### DIFF
--- a/.github/workflows/linux_and_macos.yml
+++ b/.github/workflows/linux_and_macos.yml
@@ -79,7 +79,6 @@ jobs:
       - name: Install build dependencies
         if: "${{ runner.os == 'macOS' }}"
         run: |-
-          brew tap homebrew/cask-fonts
           brew install \
             bmake \
             bsdmake \


### PR DESCRIPTION
Follow-up to #133

Related commit: 31ef5ff958073dffaf86c83049d26b80e720ff99