### PR TITLE
Fix compilation on FreeBSD

### DIFF
--- a/ttyplot.c
+++ b/ttyplot.c
@@ -7,9 +7,9 @@
 // Apache License 2.0
 //
 
-// This is needed on macOS to get the ncurses widechar API, and pkg-config fails to
-// define it.
-#ifdef __APPLE__
+// This is needed on FreeBSD and macOS to get the ncurses widechar API,
+// and pkg-config fails to define it.
+#if defined(__APPLE__) || defined(__FreeBSD__)
 #define _XOPEN_SOURCE_EXTENDED
 #else
 // This is needed for musl libc


### PR DESCRIPTION
On FreeBSD, we need to set _XOPEN_SOURCE_EXTENDED
(or __BSD_VISIBLE) to access everything we need.

A similar patch is already in use in the FreeBSD Ports:
https://github.com/freebsd/freebsd-ports/blob/main/graphics/ttyplot/files/patch-ttyplot.c.