### PR TITLE
Fix CI failure on maybe-uninitialized compiler warning

### DIFF
--- a/.github/workflows/linux_and_macos.yml
+++ b/.github/workflows/linux_and_macos.yml
@@ -147,11 +147,8 @@ jobs:
           # would error out saying "ld: unknown option: --as-needed"
           if [[ ${{ runner.os }} = macOS ]]; then
             as_needed=
-            # GCC on macOS needs this flag to suppress false positive uninitialized warnings
-            maybe_uninit_flag='-Wno-error=maybe-uninitialized'
           else
             as_needed='-Wl,--as-needed'
-            maybe_uninit_flag=
           fi
 
           # musl-gcc and gcc/macOS do not seem to support linking with sanitizers
@@ -165,7 +162,7 @@ jobs:
 
           ${MAKE} --version 2>/dev/null || true
 
-          CFLAGS="-std=c99 -pedantic -Werror ${maybe_uninit_flag} ${sanitizer} -O1" LDFLAGS="${as_needed} ${sanitizer}" ${MAKE}
+          CFLAGS="-std=c99 -pedantic -Werror ${sanitizer} -O1" LDFLAGS="${as_needed} ${sanitizer}" ${MAKE}
 
       - name: 'Install'
         env:

--- a/ttyplot.c
+++ b/ttyplot.c
@@ -322,7 +322,7 @@ static void draw_line(int x, int ph, int l1, int l2, cchar_t *c1, cchar_t *c2,
 
     // Handle drawing based on whether values are positive or negative
     if (zero_pos > 0) {  // We have negative values
-        int y1_start, y1_end, y2_start, y2_end;
+        int y1_start, y1_end;
 
         // For value 1
         if (v1 >= 0) {
@@ -335,8 +335,17 @@ static void draw_line(int x, int ph, int l1, int l2, cchar_t *c1, cchar_t *c2,
             y1_end = ph + 1 - l1;
         }
 
+        // Draw the lines
+        if (y1_start < y1_end) {
+            mvvline_set(y1_start, x, c1, y1_end - y1_start);
+        } else if (y1_start > y1_end && l1 > 0) {
+            mvvline_set(y1_end, x, c1, y1_start - y1_end);
+        }
+
         // For value 2
         if (has_v2) {
+            int y2_start, y2_end;
+
             if (v2 > 0) {
                 y2_start = ph + 1 - l2;
                 y2_end = ph + 1 - zero_pos;
@@ -347,15 +356,8 @@ static void draw_line(int x, int ph, int l1, int l2, cchar_t *c1, cchar_t *c2,
                 y2_start = ph + 1 - zero_pos;
                 y2_end = ph + 1 - zero_pos;
             }
-        }
 
-        // Draw the lines
-        if (y1_start < y1_end) {
-            mvvline_set(y1_start, x, c1, y1_end - y1_start);
-        } else if (y1_start > y1_end && l1 > 0) {
-            mvvline_set(y1_end, x, c1, y1_start - y1_end);
-        }
-        if (has_v2) {
+            // Draw the lines
             if (y2_start < y2_end) {
                 mvvline_set(y2_start, x, &c2r, y2_end - y2_start);
             } else if (y2_start > y2_end) {


### PR DESCRIPTION
Some GCC versions warn:

```text
ttyplot.c:359:16: warning: 'y2_start' may be used uninitialized [-Wmaybe-uninitialized]
[...]
ttyplot.c:359:16: warning: 'y2_end' may be used uninitialized [-Wmaybe-uninitialized]
```

These are false positives. However, in combination with the `-Werror` compiler option, they cause a [CI failure on GCC 14 / Ubuntu][gcc].

Commits 8d8d752 and 714f210 attempted to fix the failure by providing the `-Wno-error=maybe-uninitialized` compiler option. However, they did not fix the failure on Ubuntu, and they caused another [failure on clang 18 on macOS][clang]:

```text
error: unknown warning option '-Werror=maybe-uninitialized';
did you mean '-Werror=uninitialized'? [-Werror,-Wunknown-warning-option]
```

This pull request solves the issue in a different way: by moving the initialization of `y2_start` and `y2_end` closer to where they are used (within the same `if` statement), the warning goes away. Then, the compiler option `-Wno-error=maybe-uninitialized` is not needed anymore.

[gcc]: ../actions/runs/17030161145/job/48271411839
[clang]: ../actions/runs/17030161145/job/48271411825