### PR TITLE
CI: upgrade macOS runners

### DIFF
--- a/.github/workflows/linux_and_macos.yml
+++ b/.github/workflows/linux_and_macos.yml
@@ -41,17 +41,17 @@ jobs:
             clang_major_version: null
             clang_repo_suffix: null
             make: make
-            runs-on: macos-13
-          - cc: gcc-14
+            runs-on: macos-14
+          - cc: gcc-15
             clang_major_version: null
             clang_repo_suffix: null
             make: bmake
-            runs-on: macos-14
-          - cc: clang-18
-            clang_major_version: 18
+            runs-on: macos-15-intel
+          - cc: clang-20
+            clang_major_version: 20
             clang_repo_suffix: null
             make: bsdmake
-            runs-on: macos-15
+            runs-on: macos-26
     steps:
       - name: Add Clang/LLVM repositories
         if: "${{ runner.os == 'Linux' && contains(matrix.cc, 'clang') }}"


### PR DESCRIPTION
GitHub is [retiring its macOS 13 runner image][macOS-13], and has released a [macOS 26 image in public preview][macOS-26]. It's time to upgrade.

While we are at it:

  * replace macos-15 by macos-15-intel, in order to keep at least one macOS/Intel in our CI

  * replace GCC 14 (already tested on Ubuntu) by GCC 15

  * replace Clang 18 (already tested on Ubuntu) by Clang 20

The version coverage of our CI workflow is changed as this:

| component | before | after |
|-----------|--------|-------|
|   macOS   | 13–15  | 14–26 |
|   gcc     | 13–14  | 13–15 |
|   clang   |  18    | 18,20 |

[macOS-13]: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/
[macOS-26]: https://github.blog/changelog/2025-09-11-actions-macos-26-image-now-in-public-preview/