### PR TITLE
Work on smaller windows with no clock display

### DIFF
--- a/ttyplot.c
+++ b/ttyplot.c
@@ -537,13 +537,14 @@ static void paint_plot(void) {
     if (width >= WIDTH_CLOCK_MIN) {
         const char *clock_display;
         if (fake_clock) {
-            clock_display = "Thu Jan  1 00:00:00 1970 ";
+            clock_display = "Thu Jan  1 00:00:00 1970";
         } else {
             lt = localtime(&now.tv_sec);
             asctime_r(lt, ls);
+            ls[strlen(ls) - 1] = '\0';  // drop trailing newline, see asctime_r(3)
             clock_display = ls;
         }
-        mvaddstr(height - 2, width - strlen(clock_display), clock_display);
+        mvaddstr(height - 2, width - strlen(clock_display) - 1, clock_display);
     }
 
     if (colors[TEXT_COLOR] != -1)

--- a/ttyplot.c
+++ b/ttyplot.c
@@ -54,7 +54,8 @@
 #endif
 
 // Window size
-#define WIDTH_MIN 68
+#define WIDTH_MIN 44
+#define WIDTH_CLOCK_MIN 68
 #define WIDTH_MARGIN 4
 #define HEIGHT_MIN 5
 #define HEIGHT_MARGIN 4
@@ -532,15 +533,17 @@ static void paint_plot(void) {
 
     mvaddstr(height - 1, width - strlen(verstring) - 1, verstring);
 
-    const char *clock_display;
-    if (fake_clock) {
-        clock_display = "Thu Jan  1 00:00:00 1970 ";
-    } else {
-        lt = localtime(&now.tv_sec);
-        asctime_r(lt, ls);
-        clock_display = ls;
+    if (width >= WIDTH_CLOCK_MIN) {
+        const char *clock_display;
+        if (fake_clock) {
+            clock_display = "Thu Jan  1 00:00:00 1970 ";
+        } else {
+            lt = localtime(&now.tv_sec);
+            asctime_r(lt, ls);
+            clock_display = ls;
+        }
+        mvaddstr(height - 2, width - strlen(clock_display), clock_display);
     }
-    mvaddstr(height - 2, width - strlen(clock_display), clock_display);
 
     if (colors[TEXT_COLOR] != -1)
         attroff(COLOR_PAIR(TEXT_COLOR + 1));

--- a/ttyplot.c
+++ b/ttyplot.c
@@ -54,8 +54,9 @@
 #endif
 
 // Window size
+#define WIDTH_CLOCK 24  // strlen("Thu Jan  1 00:00:00 1970")
 #define WIDTH_MIN 44
-#define WIDTH_CLOCK_MIN 68
+#define WIDTH_CLOCK_MIN (WIDTH_MIN + WIDTH_CLOCK)
 #define WIDTH_MARGIN 4
 #define HEIGHT_MIN 5
 #define HEIGHT_MARGIN 4


### PR DESCRIPTION
This pull request addresses issue #213. When the terminal window width is less than 68 character cells, ttyplot refuses to plot anything. This limit comes from the space needed by the stuff displayed at the bottom which, at the minimal window width, make look like this:

```text
     │ last=8.5 min=5.0 max=8.5 avg=6.8    Sun Mar 15 15:45:37 2026
                            https://github.com/tenox7/ttyplot 1.7.4

```

This pull request alleviates the issue by removing the clock when the window is too narrow. The minimal window width is then shrunk by 24 cells, which is the width of the clock display.

There are a couple of caveats:

 * If the plotted numbers are very large, the last/…/avg display may overflow its allotted space.

 * In two-curve mode, the last/…/avg display for the second curve can collide with the ttyplot URL.

These issues are not specific to this PR though: they exist in the current master branch. For example, with a window width of 68:

**large numbers**:

```text
     │ last=18024.4 min=-31410.9 max=31420.9 avg=-3241.2  7:51 2026
                            https://github.com/tenox7/ttyplot 1.7.4

```

**two-curves**:

```text
     │ last=3.7 min=3.7 max=10.0 avg=7.8   Sun Mar 15 16:07:55 2026
       last=0.2 min=0.0 max=10.0 avg=4.6    om/tenox7/ttyplot 1.7.4
```

Possible improvements:

 * also remove the URL, or replace it with “ttyplot $VERSION”, if needed

 * print numbers in a format with a guaranteed maximum width (e.g. `%.3g`).