### PR TITLE
CI: disable sanitizers on macOS

### DIFF
--- a/.github/workflows/linux_and_macos.yml
+++ b/.github/workflows/linux_and_macos.yml
@@ -156,8 +156,8 @@ jobs:
             as_needed='-Wl,--as-needed'
           fi
 
-          # musl-gcc and gcc/macOS do not seem to support linking with sanitizers
-          if [[ ${{ matrix.cc }} =~ musl || ${{ matrix.cc }} =~ gcc && ${{ matrix.runs-on }} =~ macos ]]; then
+          # musl-gcc and compilers on macOS do not seem to support linking with sanitizers
+          if [[ ${{ matrix.cc }} =~ musl || ${{ matrix.runs-on }} =~ macos ]]; then
             sanitizer=
           else
             # ASan: https://clang.llvm.org/docs/AddressSanitizer.html


### PR DESCRIPTION
The job “clang-20/bsdmake on macos-26” has been failing systematically [since 2026-05-29][fail]. It appears this is because clang miscompiles ttyplot into a binary that produces no output. Removing the sanitizer options fixes the compilation. This was the only macOS job making use of sanitizers.

This pull request fixes the CI failure by disabling the sanitizers on all macOS jobs.

[fail]: https://github.com/tenox7/ttyplot/actions/runs/26623081645/job/78453289614